### PR TITLE
No detailed error to user, add missing translation

### DIFF
--- a/include/lang-de.php
+++ b/include/lang-de.php
@@ -12,6 +12,7 @@ $lang['Release Mail'] =	'Release Mail';
 $lang['Release Succeeded'] = "<b>Release erfolgreich!</b> Bitte überprüfen Sie ihre Mailbox.";
 $lang['Release Failed']	= "<b>Fehler!</b> Release konnte nicht durchgeführt werden. Wenden Sie sich an Ihren Administrator.<br> <br>"; 
 $lang['Mail Release'] = "Release Mail";
+$lang['Antispam Mail Release'] = "Antispam Mail Release";
 
 $lang['No ID Provided'] = 'Es wurde keine Referenznummer angegeben. Bei Problemen melden Sie sich bitte bei Ihrem Administrator';
 

--- a/php/release.php
+++ b/php/release.php
@@ -16,7 +16,15 @@ $ID = escapeshellarg($_POST['mailid']);
 exec("sudo amavisd-release $ID  2>&1", $out, $retcode );
 $msg = $out[0];
 $code = substr($msg, 0, 3);
-$retstring = $code."|".$msg;
+if($code !== "250") {
+  if($code == "450") {
+    $retstring = $code."|ID not found";
+  } else {
+    $retstring = $code."|unexpected error occured, contact administrator";
+  };
+} else {
+  $retstring = $code."|ID released";
+};
 
 echo $retstring;
 ?>


### PR DESCRIPTION
- detailed errors of amavisd-release should not displayed to users
- DE translation missed an entry