### PR TITLE
Fix support of "banned" and some cosmetic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # amavisd-release-web
-A small and simple Webinterface for the amavisd-release command
+A small and simple Webinterface for the `amavisd-release` command
 
 ## How to install:
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ A small and simple Webinterface for the amavisd-release command
   - FriendlyCaptcha: create site and secret key @ https://friendlycaptcha.com/
 - copy the amavisd-new templates from amavis-templ to your amavisd-new template or config folder
 - customize the templates and the php files for your needs (title, links etc)
-- activate the templates in /etc/amavisd/amavisd.conf (example)
+- activate the templates in `/etc/amavisd/amavisd.conf` (example)
 
   `$notify_virus_admin_templ = read_text("/etc/amavisd/template-virus-admin.txt");`
 
   `$notify_virus_recips_templ = read_text("/etc/amavisd/template-virus-recipient.txt");`
 
-- add the apache user to the sudoer file and allow "sudo amavisd-release <ID> [<RCPT>]" without password:
+- add the apache user to the sudoer file and allow `sudo amavisd-release <ID> [<RCPT>]` without password:
 
   - example #1
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A small and simple Webinterface for the amavisd-release command
 
   `$notify_virus_recips_templ = read_text("/etc/amavisd/template-virus-recipient.txt");`
 
-- add the apache user to the sudoer file and allow "sudo amavisd-release ID" without password:
+- add the apache user to the sudoer file and allow "sudo amavisd-release <ID> [<RCPT>]" without password:
 
   - example #1
 

--- a/amavis-templ/template-virus-recipient-2.12.1-extended.txt
+++ b/amavis-templ/template-virus-recipient-2.12.1-extended.txt
@@ -1,0 +1,51 @@
+#
+# =============================================================================
+# This is a template for VIRUS/BANNED/BAD-HEADER RECIPIENTS NOTIFICATIONS.
+# For syntax and customization instructions see README.customize.
+# Long header fields will be automatically wrapped by the program.
+#
+From: %f
+Date: %d
+Subject: [? [:ccat|major] |Clean mail|Clean mail|MTA-blocked mail|\
+OVERSIZED mail|INVALID HEADER in mail|Spammy|Spam|UNCHECKED contents in mail|\
+BANNED contents (%F) in mail|VIRUS (%V) in mail] TO YOU from [:mail_addr_decode|%s]
+[? [:header_field|To] |To: undisclosed-recipients:;|To: [:header_field|To]]
+[? [:header_field|Cc] |#|Cc: [:header_field|Cc]]
+Message-ID: <VR%i@%h>
+
+[? %#V |[? %#F ||BANNED CONTENTS ALERT]|VIRUS ALERT]
+
+Our content checker found
+[? %#V |#|[:wrap|78|    |  |[?%#V|viruses|virus|viruses]: %V]]
+[? %#F |#|[:wrap|78|    |  |banned [?%#F|names|name|names]: %F]]
+[? %#X |#|[[:wrap|78|    |  |%X]\n]]
+
+in an email to you [? %#V |from:|from probably faked sender:]
+  [:mail_addr_decode|%o]
+[? %#V |#|claiming to be: [:mail_addr_decode|%s]]
+
+Content type: [:ccat|name|main]#
+[? [:ccat|is_blocked_by_nonmain] ||, blocked for [:ccat|name]]
+Our internal reference code for your message is %n/%i
+
+[? %a |#|[:wrap|78||  |First upstream SMTP client IP address: [:client_addr_port] %g]]
+
+[:wrap|78||  |Received trace: [ip_proto_trace_all|%x| < ]]
+
+[:wrap|78||  |Return-Path: [:mail_addr_decode|%s][?[:dkim|envsender]|| (OK)]]
+[:wrap|78||  |From: [:mime_decode|[:header_field_octets|From]|100]\
+[?[:dkim|author]|| (dkim:AUTHOR)]]
+[? [:header_field|Sender]|#|\
+[:wrap|78||  |Sender: [:mime_decode|[:header_field_octets|Sender]|100]\
+[?[:dkim|sender]|| (dkim:SENDER)]]]
+[? %m |#|[:wrap|78||  |Message-ID: [:mail_addr_decode|%m]]]
+[? %r |#|[:wrap|78||  |Resent-Message-ID: [:mail_addr_decode|%r]]]
+[? [:useragent] |#|[:wrap|78||  |[:useragent]]]
+[? %j |#|[:wrap|78||  |Subject: [:mime_decode|[:header_field_octets|Subject]|100]]]
+[? %q |Not quarantined.|The message has been quarantined as: %q]
+
+Please contact your system administrator for details.
+
+TAKE-CARE-USE-ONLY-IN-URGENT-CASE:
+[? %q ||Self-Release-URL: https://%h/amavisd-release-web/?ID=%q&R=%R]
+

--- a/amavis-templ/template-virus-recipient.txt
+++ b/amavis-templ/template-virus-recipient.txt
@@ -37,7 +37,7 @@ Content Typ: [:ccat|name|main]#
 
 [? %q | |Sollte es sich um einen Fehlalarm handeln und Sie sind sich sicher, dass diese Mail harmlos ist, klicken sie auf diesen Link: 
 
-https://antispam.bond.de/index.php?ID=%q&R=%R
+https://%h/amavisd-release-web/?ID=%q&R=%R
 
 Dort koennen Sie die Mail aus der Quarantaene freigeben] 
 
@@ -80,6 +80,6 @@ Our internal reference code for your message is %n/%i
 [? %j |#|[:wrap|78||  |Subject: %j]]
 [? %q |Not quarantined.|The message has been quarantined as: %q]
 
-[? %q | |You can release the Mail by yourself with this Link: https://antispam.bond.de/index.php?ID=%q&R=%R]
+[? %q | |You can release the Mail by yourself with this Link: https://%h/amavisd-release-web/?ID=%q&R=%R]
 
 Please contact your system administrator for details.

--- a/amavis-templ/template-virus-recipient.txt
+++ b/amavis-templ/template-virus-recipient.txt
@@ -37,7 +37,7 @@ Content Typ: [:ccat|name|main]#
 
 [? %q | |Sollte es sich um einen Fehlalarm handeln und Sie sind sich sicher, dass diese Mail harmlos ist, klicken sie auf diesen Link: 
 
-https://antispam.bond.de/index.php?ID=%q
+https://antispam.bond.de/index.php?ID=%q&R=%R
 
 Dort koennen Sie die Mail aus der Quarantaene freigeben] 
 
@@ -80,6 +80,6 @@ Our internal reference code for your message is %n/%i
 [? %j |#|[:wrap|78||  |Subject: %j]]
 [? %q |Not quarantined.|The message has been quarantined as: %q]
 
-[? %q | |You can release the Mail by yourself with this Link: http://antispam.bond.de/index.php?ID=%q]
+[? %q | |You can release the Mail by yourself with this Link: https://antispam.bond.de/index.php?ID=%q&R=%R]
 
 Please contact your system administrator for details.

--- a/include/lang-de.php
+++ b/include/lang-de.php
@@ -19,4 +19,6 @@ $lang['Antispam Mail Release'] = 'Antispam Mail Freigabe';
 $lang['No ID Provided'] = 'Es wurde keine Referenznummer angegeben. Bei Problemen melden Sie sich bitte bei Ihrem Administrator.';
 $lang['Invalid ID Provided'] = 'Inkorrekte Referenznummer angegeben. Bei Problemen melden Sie sich bitte bei Ihrem Administrator.';
 
+$lang['Please wait'] = 'Bitte warten...';
+
 ?>

--- a/include/lang-en.php
+++ b/include/lang-en.php
@@ -11,4 +11,6 @@ $lang['Release Failed']	= '<b>Error!</b> Release was not successful. Please cont
 $lang['No ID Provided'] = 'No ID provided. In case of problems contact your administrator.';
 $lang['Invalid ID Provided'] = 'Incorrect ID provided. In case of problems contact your administrator.';
 
+$lang['Please wait'] = 'Please wait...';
+
 ?>

--- a/include/lang-it.php
+++ b/include/lang-it.php
@@ -16,4 +16,6 @@ $lang['Mail released'] = 'Messaggio Rilasciata';
 $lang['No ID Provided'] = 'Nessun numero di riferimento &egrave; stato specificato. In caso di problemi, contatta il tuo Amministratore di Sistema.';
 $lang['Invalid ID Provided'] = 'Numero non valido &egrave; stato specificato. In caso di problemi, contatta il tuo Amministratore di Sistema.';
 
+$lang['Please wait'] = 'Un momento, per favore...';
+
 ?>

--- a/index.php
+++ b/index.php
@@ -11,6 +11,12 @@
 		header("Location: php/error.php?ID=invalid");
 		die();
 	};
+
+	if(isset($_GET["R"]) && !filter_var($_GET["R"], FILTER_VALIDATE_EMAIL))
+	{
+		header("Location: php/error.php");
+		die();
+	}
 ?>
 
 <!DOCTYPE html>
@@ -124,6 +130,7 @@
 		function frmRelease(){
 			var formControl = true;
 			var mailid = "<?php Print($_GET["ID"]); ?>";
+			var rcpt = "<?php Print($_GET["R"]); ?>";
 
 			if(isHuman.length == 0) {
 				formControl = false;
@@ -136,6 +143,7 @@
 
 				var data = new FormData();
 				data.append("mailid", mailid);
+				data.append("rcpt", rcpt);
 				data.append("isHuman", isHuman);
 
 				fetch("php/release.php", {

--- a/index.php
+++ b/index.php
@@ -138,6 +138,8 @@
 
 			if(formControl) {
 				document.getElementById("message").className = 'alert';
+				document.getElementById("submitBtn").disabled = true;
+				document.getElementById("submitBtn").textContent = "<?php lang('Please wait')?>";
 				var data = "PROBLEM"; // default
 				var code;
 

--- a/php/release.php
+++ b/php/release.php
@@ -2,7 +2,9 @@
 
 include('../include/start.php');
 
-$R=""; # default empty
+# explicit recipient, default empty, only required in case of "banned"
+#  see also: https://mailing.unix.amavis-user.narkive.com/Zr5XTPyl/amavis-user-releasing-mail-from-clean-quarantine
+$R="";
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 	echo "550|not a POST request";
@@ -32,7 +34,10 @@ if(isset($_POST['rcpt']) && (strlen($_POST['rcpt']) > 0)) {
 		echo "550|POST data invalid: 'rcpt'";
 		die();
 	};
-        $R = escapeshellarg($_POST['rcpt']);
+
+	if (preg_match("/^(banned)/", $_POST['mailid'])) {
+		$R = escapeshellarg($_POST['rcpt']);
+	};
 }
 
 $postdata_array = array();
@@ -97,6 +102,9 @@ if($code !== "250") {
   };
 } else {
   $retstring = $code."|ID released: " . $ID;
+  if (strlen($R) > 0) {
+    $retstring = $retstring . " recipient: " . $R;
+  };
 };
 
 echo $retstring;

--- a/php/release.php
+++ b/php/release.php
@@ -2,6 +2,8 @@
 
 include('../include/start.php');
 
+$R=""; # default empty
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 	echo "550|not a POST request";
 	die();
@@ -23,6 +25,14 @@ if(isset($_POST['mailid']) && (strlen($_POST['mailid']) > 0)) {
 } else {
         echo "550|POST data missing or empty: 'mailid'";
         die();
+}
+
+if(isset($_POST['rcpt']) && (strlen($_POST['rcpt']) > 0)) {
+	if (!filter_var($_POST['rcpt'], FILTER_VALIDATE_EMAIL)) {
+		echo "550|POST data invalid: 'rcpt'";
+		die();
+	};
+        $R = escapeshellarg($_POST['rcpt']);
 }
 
 $postdata_array = array();
@@ -71,7 +81,7 @@ if(intval($responseKeys["success"]) !== 1) {
     die();
 }
 
-exec("sudo amavisd-release $ID  2>&1", $out, $retcode );
+exec("sudo amavisd-release $ID $R 2>&1", $out, $retcode );
 if ($retcode != 0) {
     echo "550|release execution failed";
     die();


### PR DESCRIPTION
"banned" e-mails cannot be released currently, because here the e-mail address is required, see also https://mailing.unix.amavis-user.narkive.com/Zr5XTPyl/amavis-user-releasing-mail-from-clean-quarantine

This PR adds support for the e-mail address and also includes an extended notification template based on the vanilla one inside amavis 2.12.1.